### PR TITLE
Add support for tvOS 

### DIFF
--- a/PeachCollector.xcodeproj/project.pbxproj
+++ b/PeachCollector.xcodeproj/project.pbxproj
@@ -7,6 +7,35 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		486DFF2E24AB94EE00CBF530 /* PeachCollector.xcdatamodel in Sources */ = {isa = PBXBuildFile; fileRef = 95354714233A194A0096AE60 /* PeachCollector.xcdatamodel */; };
+		486DFF2F24AB94F900CBF530 /* PeachCollectorQueue.h in Headers */ = {isa = PBXBuildFile; fileRef = 953546F4233A16780096AE60 /* PeachCollectorQueue.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		486DFF3024AB94F900CBF530 /* PeachCollectorQueue.m in Sources */ = {isa = PBXBuildFile; fileRef = 953546F3233A16780096AE60 /* PeachCollectorQueue.m */; };
+		486DFF3124AB94F900CBF530 /* PeachCollectorReachability.h in Headers */ = {isa = PBXBuildFile; fileRef = 9530214D235081D80083E29F /* PeachCollectorReachability.h */; };
+		486DFF3224AB94F900CBF530 /* PeachCollectorReachability.m in Sources */ = {isa = PBXBuildFile; fileRef = 9530214E235081D80083E29F /* PeachCollectorReachability.m */; };
+		486DFF3324AB94F900CBF530 /* PeachCollectorDataStore.h in Headers */ = {isa = PBXBuildFile; fileRef = 9530215923585D2D0083E29F /* PeachCollectorDataStore.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		486DFF3424AB94F900CBF530 /* PeachCollectorDataStore.m in Sources */ = {isa = PBXBuildFile; fileRef = 9530215A23585D2D0083E29F /* PeachCollectorDataStore.m */; };
+		486DFF3524AB94FD00CBF530 /* PeachCollectorPublisher.h in Headers */ = {isa = PBXBuildFile; fileRef = 953546EE233A16780096AE60 /* PeachCollectorPublisher.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		486DFF3624AB94FD00CBF530 /* PeachCollectorPublisher.m in Sources */ = {isa = PBXBuildFile; fileRef = 953546FD233A16790096AE60 /* PeachCollectorPublisher.m */; };
+		486DFF3724AB94FD00CBF530 /* PeachCollectorPublisherEventStatus.h in Headers */ = {isa = PBXBuildFile; fileRef = 953546EB233A16770096AE60 /* PeachCollectorPublisherEventStatus.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		486DFF3824AB94FD00CBF530 /* PeachCollectorPublisherEventStatus.m in Sources */ = {isa = PBXBuildFile; fileRef = 953546F7233A16790096AE60 /* PeachCollectorPublisherEventStatus.m */; };
+		486DFF3924AB950300CBF530 /* PeachCollectorContext.h in Headers */ = {isa = PBXBuildFile; fileRef = 953546FB233A16790096AE60 /* PeachCollectorContext.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		486DFF3A24AB950300CBF530 /* PeachCollectorContext.m in Sources */ = {isa = PBXBuildFile; fileRef = 953546F1233A16780096AE60 /* PeachCollectorContext.m */; };
+		486DFF3B24AB950300CBF530 /* PeachCollectorContextComponent.h in Headers */ = {isa = PBXBuildFile; fileRef = 953546EC233A16780096AE60 /* PeachCollectorContextComponent.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		486DFF3C24AB950300CBF530 /* PeachCollectorContextComponent.m in Sources */ = {isa = PBXBuildFile; fileRef = 953546FA233A16790096AE60 /* PeachCollectorContextComponent.m */; };
+		486DFF3D24AB950300CBF530 /* PeachCollectorProperties.h in Headers */ = {isa = PBXBuildFile; fileRef = 953546ED233A16780096AE60 /* PeachCollectorProperties.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		486DFF3E24AB950300CBF530 /* PeachCollectorProperties.m in Sources */ = {isa = PBXBuildFile; fileRef = 953546FC233A16790096AE60 /* PeachCollectorProperties.m */; };
+		486DFF3F24AB950300CBF530 /* PeachCollectorDynamicProperties.h in Headers */ = {isa = PBXBuildFile; fileRef = 953547A3233CDC850096AE60 /* PeachCollectorDynamicProperties.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		486DFF4024AB950300CBF530 /* PeachCollectorDynamicProperties.m in Sources */ = {isa = PBXBuildFile; fileRef = 953547A4233CDC850096AE60 /* PeachCollectorDynamicProperties.m */; };
+		486DFF4124AB950300CBF530 /* PeachCollectorEvent.h in Headers */ = {isa = PBXBuildFile; fileRef = 953546F0233A16780096AE60 /* PeachCollectorEvent.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		486DFF4224AB950300CBF530 /* PeachCollectorEvent.m in Sources */ = {isa = PBXBuildFile; fileRef = 953546F9233A16790096AE60 /* PeachCollectorEvent.m */; };
+		486DFF4324AB950700CBF530 /* PeachCollector.h in Headers */ = {isa = PBXBuildFile; fileRef = 953546D3233A15BD0096AE60 /* PeachCollector.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		486DFF4424AB950700CBF530 /* PeachCollector.m in Sources */ = {isa = PBXBuildFile; fileRef = 953546F6233A16780096AE60 /* PeachCollector.m */; };
+		486DFF4524AB950700CBF530 /* PeachCollectorDataFormat.h in Headers */ = {isa = PBXBuildFile; fileRef = 953546EF233A16780096AE60 /* PeachCollectorDataFormat.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		486DFF4624AB950700CBF530 /* PeachCollectorDataFormat.m in Sources */ = {isa = PBXBuildFile; fileRef = 953546F8233A16790096AE60 /* PeachCollectorDataFormat.m */; };
+		486DFF4724AB950700CBF530 /* PeachCollectorNotifications.h in Headers */ = {isa = PBXBuildFile; fileRef = 953547F9234B2A9D0096AE60 /* PeachCollectorNotifications.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		486DFF4824AB950700CBF530 /* PeachCollectorNotifications.m in Sources */ = {isa = PBXBuildFile; fileRef = 953547FA234B2A9D0096AE60 /* PeachCollectorNotifications.m */; };
+		486DFF4924AB955900CBF530 /* PeachPersistentContainer.m in Sources */ = {isa = PBXBuildFile; fileRef = 95354717233A1FCB0096AE60 /* PeachPersistentContainer.m */; };
+		486DFF4A24AB955C00CBF530 /* PeachPersistentContainer.h in Headers */ = {isa = PBXBuildFile; fileRef = 95354716233A1FCB0096AE60 /* PeachPersistentContainer.h */; };
 		9530214F235081D80083E29F /* PeachCollectorReachability.h in Headers */ = {isa = PBXBuildFile; fileRef = 9530214D235081D80083E29F /* PeachCollectorReachability.h */; };
 		95302150235081D80083E29F /* PeachCollectorReachability.m in Sources */ = {isa = PBXBuildFile; fileRef = 9530214E235081D80083E29F /* PeachCollectorReachability.m */; };
 		9530215B23585D2D0083E29F /* PeachCollectorDataStore.h in Headers */ = {isa = PBXBuildFile; fileRef = 9530215923585D2D0083E29F /* PeachCollectorDataStore.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -116,6 +145,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		486DFEF524AB935700CBF530 /* PeachCollector.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = PeachCollector.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		9530214D235081D80083E29F /* PeachCollectorReachability.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PeachCollectorReachability.h; sourceTree = "<group>"; };
 		9530214E235081D80083E29F /* PeachCollectorReachability.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PeachCollectorReachability.m; sourceTree = "<group>"; };
 		9530215923585D2D0083E29F /* PeachCollectorDataStore.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PeachCollectorDataStore.h; sourceTree = "<group>"; };
@@ -177,6 +207,13 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		486DFEF224AB935700CBF530 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		953546CD233A15BD0096AE60 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -245,6 +282,7 @@
 				953546D9233A15BD0096AE60 /* PeachCollectorTests.xctest */,
 				9535475A233B67AA0096AE60 /* PeachCollectorDemo.app */,
 				9535478C233B8A5E0096AE60 /* PeachCollectorSwiftDemo.app */,
+				486DFEF524AB935700CBF530 /* PeachCollector.framework */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -350,6 +388,27 @@
 /* End PBXGroup section */
 
 /* Begin PBXHeadersBuildPhase section */
+		486DFEF024AB935700CBF530 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				486DFF3924AB950300CBF530 /* PeachCollectorContext.h in Headers */,
+				486DFF2F24AB94F900CBF530 /* PeachCollectorQueue.h in Headers */,
+				486DFF3524AB94FD00CBF530 /* PeachCollectorPublisher.h in Headers */,
+				486DFF3B24AB950300CBF530 /* PeachCollectorContextComponent.h in Headers */,
+				486DFF3724AB94FD00CBF530 /* PeachCollectorPublisherEventStatus.h in Headers */,
+				486DFF4124AB950300CBF530 /* PeachCollectorEvent.h in Headers */,
+				486DFF4724AB950700CBF530 /* PeachCollectorNotifications.h in Headers */,
+				486DFF4A24AB955C00CBF530 /* PeachPersistentContainer.h in Headers */,
+				486DFF3D24AB950300CBF530 /* PeachCollectorProperties.h in Headers */,
+				486DFF3F24AB950300CBF530 /* PeachCollectorDynamicProperties.h in Headers */,
+				486DFF3324AB94F900CBF530 /* PeachCollectorDataStore.h in Headers */,
+				486DFF4324AB950700CBF530 /* PeachCollector.h in Headers */,
+				486DFF4524AB950700CBF530 /* PeachCollectorDataFormat.h in Headers */,
+				486DFF3124AB94F900CBF530 /* PeachCollectorReachability.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		953546CB233A15BD0096AE60 /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
@@ -374,6 +433,25 @@
 /* End PBXHeadersBuildPhase section */
 
 /* Begin PBXNativeTarget section */
+		486DFEF424AB935700CBF530 /* PeachCollector tvOS */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 486DFEFC24AB935700CBF530 /* Build configuration list for PBXNativeTarget "PeachCollector tvOS" */;
+			buildPhases = (
+				486DFEF024AB935700CBF530 /* Headers */,
+				486DFEF124AB935700CBF530 /* Sources */,
+				486DFEF224AB935700CBF530 /* Frameworks */,
+				486DFEF324AB935700CBF530 /* Resources */,
+				486DFF6324AB9D7C00CBF530 /* Run Script */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "PeachCollector tvOS";
+			productName = "PeachCollector tvOS";
+			productReference = 486DFEF524AB935700CBF530 /* PeachCollector.framework */;
+			productType = "com.apple.product-type.framework";
+		};
 		953546CF233A15BD0096AE60 /* PeachCollector */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 953546E4233A15BD0096AE60 /* Build configuration list for PBXNativeTarget "PeachCollector" */;
@@ -456,10 +534,13 @@
 		953546C7233A15BD0096AE60 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastSwiftUpdateCheck = 1100;
+				LastSwiftUpdateCheck = 1150;
 				LastUpgradeCheck = 1120;
 				ORGANIZATIONNAME = "European Broadcasting Union";
 				TargetAttributes = {
+					486DFEF424AB935700CBF530 = {
+						CreatedOnToolsVersion = 11.5;
+					};
 					953546CF233A15BD0096AE60 = {
 						CreatedOnToolsVersion = 11.0;
 						LastSwiftMigration = 1100;
@@ -489,6 +570,7 @@
 			projectRoot = "";
 			targets = (
 				953546CF233A15BD0096AE60 /* PeachCollector */,
+				486DFEF424AB935700CBF530 /* PeachCollector tvOS */,
 				953546D8233A15BD0096AE60 /* PeachCollectorTests */,
 				95354759233B67AA0096AE60 /* PeachCollectorDemo */,
 				9535478B233B8A5E0096AE60 /* PeachCollectorSwiftDemo */,
@@ -497,6 +579,13 @@
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
+		486DFEF324AB935700CBF530 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		953546CE233A15BD0096AE60 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -534,6 +623,24 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
+		486DFF6324AB9D7C00CBF530 /* Run Script */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "Run Script";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "#set -o xtrace\nfind \"${DERIVED_SOURCES_DIR}/CoreDataGenerated/PeachCollector\" -type f -name \"*.h\" -exec cp {} \"${BUILT_PRODUCTS_DIR}/${PUBLIC_HEADERS_FOLDER_PATH}\" \\;\n";
+		};
 		95354754233A45620096AE60 /* ShellScript */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -554,6 +661,28 @@
 /* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
+		486DFEF124AB935700CBF530 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				486DFF4924AB955900CBF530 /* PeachPersistentContainer.m in Sources */,
+				486DFF3E24AB950300CBF530 /* PeachCollectorProperties.m in Sources */,
+				486DFF3624AB94FD00CBF530 /* PeachCollectorPublisher.m in Sources */,
+				486DFF4024AB950300CBF530 /* PeachCollectorDynamicProperties.m in Sources */,
+				486DFF3224AB94F900CBF530 /* PeachCollectorReachability.m in Sources */,
+				486DFF2E24AB94EE00CBF530 /* PeachCollector.xcdatamodel in Sources */,
+				486DFF4224AB950300CBF530 /* PeachCollectorEvent.m in Sources */,
+				486DFF4824AB950700CBF530 /* PeachCollectorNotifications.m in Sources */,
+				486DFF3024AB94F900CBF530 /* PeachCollectorQueue.m in Sources */,
+				486DFF4424AB950700CBF530 /* PeachCollector.m in Sources */,
+				486DFF3424AB94F900CBF530 /* PeachCollectorDataStore.m in Sources */,
+				486DFF4624AB950700CBF530 /* PeachCollectorDataFormat.m in Sources */,
+				486DFF3824AB94FD00CBF530 /* PeachCollectorPublisherEventStatus.m in Sources */,
+				486DFF3C24AB950300CBF530 /* PeachCollectorContextComponent.m in Sources */,
+				486DFF3A24AB950300CBF530 /* PeachCollectorContext.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		953546CC233A15BD0096AE60 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -668,6 +797,58 @@
 /* End PBXVariantGroup section */
 
 /* Begin XCBuildConfiguration section */
+		486DFEFA24AB935700CBF530 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 13;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = PeachCollector/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0.9;
+				PRODUCT_BUNDLE_IDENTIFIER = ch.ebu.PeachCollector;
+				PRODUCT_NAME = PeachCollector;
+				SDKROOT = appletvos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = 3;
+				TVOS_DEPLOYMENT_TARGET = 13.0;
+			};
+			name = Debug;
+		};
+		486DFEFB24AB935700CBF530 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 13;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = PeachCollector/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0.9;
+				PRODUCT_BUNDLE_IDENTIFIER = ch.ebu.PeachCollector;
+				PRODUCT_NAME = PeachCollector;
+				SDKROOT = appletvos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = 3;
+				TVOS_DEPLOYMENT_TARGET = 13.0;
+			};
+			name = Release;
+		};
 		953546E2233A15BD0096AE60 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -951,6 +1132,15 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		486DFEFC24AB935700CBF530 /* Build configuration list for PBXNativeTarget "PeachCollector tvOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				486DFEFA24AB935700CBF530 /* Debug */,
+				486DFEFB24AB935700CBF530 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		953546CA233A15BD0096AE60 /* Build configuration list for PBXProject "PeachCollector" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (

--- a/PeachCollector.xcodeproj/xcshareddata/xcschemes/PeachCollector tvOS.xcscheme
+++ b/PeachCollector.xcodeproj/xcshareddata/xcschemes/PeachCollector tvOS.xcscheme
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1150"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "486DFEF424AB935700CBF530"
+               BuildableName = "PeachCollector.framework"
+               BlueprintName = "PeachCollector tvOS"
+               ReferencedContainer = "container:PeachCollector.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "486DFEF424AB935700CBF530"
+            BuildableName = "PeachCollector.framework"
+            BlueprintName = "PeachCollector tvOS"
+            ReferencedContainer = "container:PeachCollector.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/PeachCollector/Queue/PeachCollectorQueue.m
+++ b/PeachCollector/Queue/PeachCollectorQueue.m
@@ -227,6 +227,8 @@
                         [self checkPublisherNamed:publisherName];
                     }
                     
+                    #if TARGET_OS_IOS
+
                     if ([[PeachCollector sharedCollector] isUnitTesting]) {
                         dispatch_async(dispatch_get_main_queue(), ^{
                             if ([[UIApplication sharedApplication] applicationState] == UIApplicationStateBackground) {
@@ -246,6 +248,7 @@
                                                                           object:nil
                                                                         userInfo:@{ PeachCollectorNotificationLogKey : [NSString stringWithFormat:@"%@ : Published %d events", publisherName, (int)events.count] }];
                     }
+                    #endif
                 }
                 
                 [self endBackgroundTask];


### PR DESCRIPTION
This PR adds support for tvOS development. 

This PR adds a new target PeachCollector tvOS. This target shares the same code, info.plist and product name as PeachCollector. This is a standard enough way of supporting multiple platforms from within Xcode.

More information can be seen here: https://iosmentor.io/swift-frameworks-ios-watchos-tvos/

I didn't add a sample project as yet so the changes are isolated.

Each file now belongs to both targets and the only code change is the local notification for unitTests

 