### PR TITLE
Added speculative fix for invalid memory access when app is in background

### DIFF
--- a/Sources/PeachCollector/PeachCollectorEvent.m
+++ b/Sources/PeachCollector/PeachCollectorEvent.m
@@ -246,7 +246,7 @@
 
 - (BOOL)shouldBeFlushedWhenReceivedInBackgroundState
 {
-    if (self.type != nil) {
+    if (self != nil && self.type != nil) {
         return [[[PeachCollector sharedCollector] flushableEventTypes] containsObject:self.type];
     }
     return NO;


### PR DESCRIPTION
This is a speculative fix for solving the issue regarding the invalid memory in #2 

## Theory 
When the App is in the background at least 2 events get logged with the completionBlock in `PeachCollectorQueue.m`:
``` c
        dispatch_async(dispatch_get_main_queue(), ^{
            if ([[UIApplication sharedApplication] applicationState] != UIApplicationStateActive
                && [addedEvent shouldBeFlushedWhenReceivedInBackgroundState]) {
                [self flush];
            }
        
            [self checkPublishers];
        });
```
this codeblock then gets added to the queue multiple times, same as the number of events.
When the first queue later gets to the first event everything works. However, somewhere in the `flush` or `checkPublishers` call the second event get processed and deleted. 
When the queue then gets to processing the second event the `addedEvent` object is nil, causing the `shouldBeFlushedWhenReceivedInBackgroundState` to crash. 

Haven't been able to replicate this, therefore its purely speculative but I think it's worth trying to see if this solves our crashes